### PR TITLE
Update LaravelFS command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This will prompt you the same way as `laravelfs new`, but instead of creating a 
 List all saved templates:
 
 ```sh
-laravelfs template:show
+laravelfs templates
 ```
 
 Or view a specific template:


### PR DESCRIPTION
## Description

Replaced the deprecated `:show` command with the updated `s` command in the README documentation. This ensures the guide remains accurate and aligns with the latest functionality.

## Additional Notes

None.