### PR TITLE
Add troubleshooting guide and improve error handling in LaravelFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,34 @@ A starter kit must meet the following requirements:
 
 ---
 
+## **🐧 Ubuntu Users: Fixing LaravelFS Command Not Found Issue**
+
+If you installed LaravelFS but **can’t run the `laravelfs` command**,
+it might be because Composer's global bin folder is **not in your system's PATH**.
+
+### **🔧 Solution: Add Composer Bin to PATH**
+1️⃣ Open your terminal and edit the `~/.bashrc` file:
+   ```sh
+   nano ~/.bashrc
+   ```  
+_(If needed, use `sudo nano ~/.bashrc`)_
+
+2️⃣ Add this line at the **bottom** of the file:
+   ```sh
+   export PATH="$PATH:$HOME/.config/composer/vendor/bin"
+   ```  
+
+3️⃣ Save the file (`CTRL + X`, then `Y`, then `Enter`).
+
+4️⃣ Apply the changes:
+   ```sh
+   source ~/.bashrc
+   ```  
+
+✅ Now, try running `laravelfs` again—it should work! 🚀
+
+---
+
 ## **Contributing**
 Thank you for considering contributing to LaravelFS! We welcome contributions to improve the installer and keep it updated. Please submit issues and pull requests to the [GitHub repository](https://github.com/HichemTab-tech/LaravelFS).
 

--- a/bin/laravelfs
+++ b/bin/laravelfs
@@ -9,7 +9,7 @@ if (file_exists(__DIR__.'/../../../autoload.php')) {
 }
 
 // Define our own version and the Laravel Installer version we aim to match.
-$laravelFSVersion = '1.2.0';
+$laravelFSVersion = '1.2.1';
 $laravelInstallerVersion = '5.13.0';
 
 // Compose the displayed version string.

--- a/tests/Unit/NewTemplateCommandTest.php
+++ b/tests/Unit/NewTemplateCommandTest.php
@@ -9,12 +9,13 @@ beforeEach(function () {
     // Create a dummy NewTemplateCommand that overrides saveTemplateCommand() to capture the saved template.
     $this->command = new class extends NewTemplateCommand {
         public array|null $savedTemplate = null;
-        public function saveTemplateCommand($templateName, $templateDescription, $templateCommand): void {
+        public function saveTemplateCommand($templateName, $templateDescription, $templateCommand): bool {
             $this->savedTemplate = [
                 'name'        => $templateName,
                 'description' => $templateDescription,
                 'command'     => $templateCommand,
             ];
+            return true;
         }
     };
 


### PR DESCRIPTION
# LaravelFS Pull Request

## Description

This pull request includes the following updates:
- Added a troubleshooting section to the README for resolving the "command not found" issue caused by Composer's bin folder not being in the PATH on Ubuntu.
- Refactored `saveTemplateCommand` to return a boolean indicating success or failure, enhancing error handling by incorporating failure messages and return code logic.
- Updated project version to 1.2.1 to reflect these changes.

## Additional Notes

No additional notes at this time.