### PR TITLE
Update LaravelFS and improve custom starter handling

### DIFF
--- a/bin/laravelfs
+++ b/bin/laravelfs
@@ -9,8 +9,8 @@ if (file_exists(__DIR__.'/../../../autoload.php')) {
 }
 
 // Define our own version and the Laravel Installer version we aim to match.
-$laravelFSVersion = '1.2.1';
-$laravelInstallerVersion = '5.13.0';
+$laravelFSVersion = '1.2.2';
+$laravelInstallerVersion = '5.14.0';
 
 // Compose the displayed version string.
 $displayVersion = sprintf('%s (advanced from Laravel Installer %s)', $laravelFSVersion, $laravelInstallerVersion);

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -77,7 +77,8 @@ class NewCommand extends Command
             ->addOption('teams', null, InputOption::VALUE_NONE, 'Indicates whether Jetstream should be scaffolded with team support')
             ->addOption('verification', null, InputOption::VALUE_NONE, 'Indicates whether Jetstream should be scaffolded with email verification support')
 
-            ->addOption('custom-starter', null, InputOption::VALUE_REQUIRED, 'Custom Starter (Provide your own starter-kit)')
+            ->addOption('using', null, InputOption::VALUE_OPTIONAL, 'Install a custom starter kit from a community maintained package')
+            ->addOption('custom-starter', null, InputOption::VALUE_REQUIRED, 'Custom Starter (Provide your own starter-kit) same thing as --using', '')
 
             // from new installer
             ->addOption('react', null, InputOption::VALUE_NONE, 'Install the React Starter Kit')
@@ -117,6 +118,10 @@ class NewCommand extends Command
   |______\__,_|_|  \__,_| \_/ \___|_|</>'.PHP_EOL.PHP_EOL);
 
         $this->ensureExtensionsAreAvailable();
+
+        if ($input->getOption('using')) {
+            $input->setOption('custom-starter', $input->getOption('using'));
+        }
 
         if ($this->isCreatingTemplate()) {
             if (!$input->getArgument('template-name')) {


### PR DESCRIPTION
# LaravelFS Pull Request

## Description
Updated LaravelFS to version 1.2.2 and Laravel Installer to 5.14.0. Introduced the `--using` option as an alias for `--custom-starter` to enhance usability and synchronized the handling of both options for consistent behavior.

## Additional Notes
None.